### PR TITLE
Fix version filter for packages without version

### DIFF
--- a/src/private/Get-WinGetPackage.ps1
+++ b/src/private/Get-WinGetPackage.ps1
@@ -9,5 +9,5 @@ function Get-WinGetPackage {
 	# We apply additional package name filtering when using wildcards to make WinGet's wildcard behavior more PowerShell-esque
 	Cobalt\Get-WinGetPackage |
 		Where-Object {$Request.IsMatch($_.ID)} |
-			Where-Object {-Not $Request.Version -Or $_.Version -And $Request.Version.Satisfies($_.Version)}
+			Where-Object {-Not $Request.Version -Or ($_.Version -And $Request.Version.Satisfies($_.Version))}
 }

--- a/src/private/Get-WinGetPackage.ps1
+++ b/src/private/Get-WinGetPackage.ps1
@@ -9,5 +9,5 @@ function Get-WinGetPackage {
 	# We apply additional package name filtering when using wildcards to make WinGet's wildcard behavior more PowerShell-esque
 	Cobalt\Get-WinGetPackage |
 		Where-Object {$Request.IsMatch($_.ID)} |
-			Where-Object {-Not $Request.Version -Or $Request.Version.Satisfies($_.Version)}
+			Where-Object {-Not $Request.Version -Or $_.Version -And $Request.Version.Satisfies($_.Version)}
 }


### PR DESCRIPTION
Fix error for `Version` parameter when packages without versions are present on the system.

```
PS C:\> Get-Package -Version 1.3.2.4 -Verbose
Get-Package: Cannot convert argument "version", with value: "", for "Satisfies" to type "AnyPackage.Provider.PackageVersion": "Cannot convert value "" to type "AnyPackage.Provider.PackageVersion". Error: "Value cannot be whitespace.""
```